### PR TITLE
changed outputs and update to handle samplesheets divided into parts.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
-# TSO500 v1.5.1
+# TSO500 v1.6.0
 
 ## What does this app do?
 Runs the Illumina TSO500 local analysis app.
+Note: this version of the app has been designed to support the analysis pipeline being run multiple times for a single run, i.e. for a 48 sample run, the samplesheet is split into 3 separate samplesheets containing up to 16 samples each (process handled by https://github.com/moka-guys/automate_demultiplex), and the pipeline set off once for each samplesheet. It therefore renames certain files and outputs to reflect this, e.g. the MetricsOutput.tsv file is renamed to MetricsOutputPart1.tsv. 
 
 ## What inputs are required for this app to run?
 * TSO500_ruo - a zip file (originally provided by Illumina) containing the TSO500 local analysis app.
 * DNAnexus project name- provided as a string. NB input is not the project ID
+* runfolder name (string)
 * Samplesheet
 * analysis_options -  a string which can be passed to the ruo command line
 
 ## How does this app work?
-* The DNAnexus project name is used to create the runfolder name variable. The runfolder name is the same as the project name without the '002_' prefix
 * The following command was used to download the files: dx download -r project_name:runfolder_name
 * Note: The runfolder is no longer expected to be archived (e.g .tar)
 * Once the files are downloaded to a folder, the path is provided to TruSight_Oncology_500_RUO.sh
 * Runs the TruSight_Oncology_500_RUO.sh (within the TSO500 local app zip file) providing arguments for analysis folder, runfolder, samplesheet, resourcesFolder and any other analysis options given as an input ($analysis_options)
+* output files are organised to allow them to be accessed by downstream analyses such as coverage
 
 
 ## What does this app output
 * RUO_stdout.txt - STDout from RUO. Saved into /logs
 * The analysis folder. Saved into /analysis_folder
-* results zip folders for each Pan number containing zipped folders for each sample and the metrics.tsv.
+* zipped results folder for each sample
 * fastqs - the content of analysis_folder/Logs_Intermediates/CollapsedReads (contains fastqs and all logs)
 * stitchedrealigned BAMs - the content of analysis_folder/Logs_Intermediates/StitchedRealigned (contains BAMs and all logs)
 * results vcfs - the content of analysis_folder/Results (contains all results vcfs)
@@ -30,6 +32,5 @@ Runs the Illumina TSO500 local analysis app.
 ## Notes
 * Only tested from starting point of BCLs
 * analysis_options is not thoroughly tested.
-* Samplesheet input could be made optional in future - if not specified the analysis app looks for SampleSheet.csv in top level of runfolder
 
-## This app was made by Viapath Genome Informatics
+## This app was made by Synnovis Genome Informatics

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What does this app do?
 Runs the Illumina TSO500 local analysis app.
-Note: this version of the app has been designed to support the analysis pipeline being run multiple times for a single run, i.e. for a 48 sample run, the samplesheet is split into 3 separate samplesheets containing up to 16 samples each (process handled by https://github.com/moka-guys/automate_demultiplex), and the pipeline set off once for each samplesheet. It therefore renames certain files and outputs to reflect this, e.g. the MetricsOutput.tsv file is renamed to MetricsOutputPart1.tsv. 
+Note: this version of the app has been designed to support the analysis pipeline being run multiple times for a single run, i.e. for a 48 sample run, the samplesheet is split into 3 separate samplesheets containing up to 16 samples each. That process is handled by the [automated scripts](https://github.com/moka-guys/automate_demultiplex), and the pipeline set off once for each samplesheet. It therefore renames certain files and outputs to reflect this, e.g. the MetricsOutput.tsv file is renamed to MetricsOutputPart1.tsv. 
 
 ## What inputs are required for this app to run?
 * TSO500_ruo - a zip file (originally provided by Illumina) containing the TSO500 local analysis app.

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,9 +1,9 @@
 {
-  "name": "TSO500_v1.5.1",
-  "title": "TSO500_v1.5.1",
-  "summary": "v1.5.1 - TSO500",
+  "name": "TSO500_v1.6.0",
+  "title": "TSO500_v1.6.0",
+  "summary": "v1.6.0 - TSO500",
   "properties": {
-    "github release": "v1.5.1"
+    "github release": "v1.6.0"
   },
   "dxapi": "1.0.0",
   "inputSpec": [
@@ -18,7 +18,14 @@
     {
       "name": "project_name",
       "label": "project name",
-      "help": "project to be analysed",
+      "help": "DNAnexus project containing the runfolder",
+      "class": "string",
+      "optional": false
+    },
+    {
+      "name": "runfolder_name",
+      "label": "runfolder name",
+      "help": "runfolder name e.g. 999_A01229_0000_ABCDEFGH_TSO999",
       "class": "string",
       "optional": false
     },
@@ -81,9 +88,9 @@
       "optional": true
     },
     {
-      "name": "results_zip",
-      "label": "zipped results folder",
-      "help": "zipped results folder.",
+      "name": "results_zip", 
+      "label": "zipped results folders",
+      "help": "zipped results folders.",
       "class": "array:file",
       "optional": true
     },

--- a/src/code.sh
+++ b/src/code.sh
@@ -5,7 +5,6 @@ set -x +e
 mark-section "download inputs"
 
 samplesheet_part=$(echo $samplesheet_name | grep -o -E "Part[0-9]{1}")
-#echo $samplesheet_name
 
 mkdir -p runfolder TSO500_ruo out/logs/logs out/analysis_folder out/results_zip/analysis_folder/ /home/dnanexus/out/fastqs/analysis_folder/Logs_Intermediates/CollapsedReads /home/dnanexus/out/bams_for_coverage/analysis_folder/Logs_Intermediates/StitchedRealigned /home/dnanexus/out/results_vcfs/analysis_folder/Results /home/dnanexus/out/results_zip/results/ /home/dnanexus/out/metrics_tsv/QC /home/dnanexus/out/QC_files/QC/bclconvert/Lane_1$samplesheet_part /home/dnanexus/out/QC_files/QC/bclconvert/Lane_2$samplesheet_part
 


### PR DESCRIPTION
… closes issue #13

output individual zip file for each sample. 
Checks for the samplesheet part used, and re-names metricsoutput and bcl convert data to reflect the samplesheet part. This is needed to allow multiqc to work downstream.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/dnanexus_tso500/14)
<!-- Reviewable:end -->
